### PR TITLE
Restrict default GitHub token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -3,6 +3,9 @@ name: Validate Docker Build
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate-docker-build:
     name: Build Docker Image (no push)


### PR DESCRIPTION
## Summary
- restrict the default GitHub token permissions for the CI workflow to read-only
- restrict the default GitHub token permissions for the Docker validation workflow to read-only

## Testing
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cfcc4678248323a3de424e20d01e4c